### PR TITLE
Optimize the docker build times and sizes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
-!target/release/soda_test_service
+!src
+!Cargo.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,35 @@
-FROM rust:1.31
+# Inspired by https://whitfin.io/speeding-up-rust-docker-builds/
+# Step 1 : build the optimized binary
+FROM rust:1.32-slim as build
 
-# Add the released binary
-ADD target/release/soda_test_service /soda/soda_test_service
-ADD .env /soda/.env
-RUN ls /soda/*
+# create a new empty shell project
+RUN USER=root cargo new --bin soda-test-service
+WORKDIR /soda-test-service
 
-# Install dependencies
-RUN apt-get -qqy update \
-  && apt-get -qqy install \
-  openssl \
-  libssl-dev \
-  pkg-config \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+# copy over the manifests
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
 
-WORKDIR /soda
+# this build step will cache the dependencies
+# after the first build
+RUN cargo build --release
+RUN rm src/*.rs
+
+# copy the source tree
+COPY ./src ./src
+
+# build for release
+RUN rm ./target/release/deps/soda_test_service*
+RUN cargo build --release
+
+# Step 2 : run the application in a slim container
+# without cargo, the toolchain, ...
+FROM debian:jessie-slim
+
+COPY --from=build /soda-test-service/target/release/soda-test-service .
 EXPOSE 8080
 
 # This command run the test service which listen on the specified address:port
 # and forward http requests to the specified address:port.
 # Arguments are : LISTEN ADDR, LISTEN PORT, FWD ADDR, FWD PORT
-CMD /soda/soda_test_service 0.0.0.0 8080 $HUB_PORT_4444_TCP_ADDR $HUB_PORT_4444_TCP_PORT
+CMD ./soda-test-service 0.0.0.0 8080 $HUB_PORT_4444_TCP_ADDR $HUB_PORT_4444_TCP_PORT

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TEST_SERVICE_IMAGE_NAME=soda/test-service
 TEST_SERVICE_IMAGE_VERSION=0.1.1
 
 build:
-	docker build -t soda/test-service .
+	docker build -t $(TEST_SERVICE_IMAGE_NAME) .
 
 tag: build
 	docker tag $(TEST_SERVICE_IMAGE_NAME) $(REGISTRY)/$(TEST_SERVICE_IMAGE_NAME):$(TEST_SERVICE_IMAGE_VERSION)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - local-network
 
   test-service:
-    image: soda/test-service:0.1.0
+    image: soda/test-service:0.1.1
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
- Use a cache during the build
- Chain builds and copy the artifact to the last one (we use debian:jessie-slim)